### PR TITLE
Remove duplicate forward declaration of struct repository

### DIFF
--- a/dir.h
+++ b/dir.h
@@ -43,7 +43,6 @@ struct repository;
  *
  */
 
-struct repository;
 
 struct dir_entry {
 	unsigned int len;


### PR DESCRIPTION
## Summary
The `struct repository;` forward declaration appears twice in `dir.h`: once at line 10 and again at line 46. This duplication is unnecessary and likely unintentional.

Removing the second declaration has no impact on compilation, as verified by a clean build.